### PR TITLE
Update zh_cn

### DIFF
--- a/common/src/main/resources/assets/stonezone/lang/zh_cn.json
+++ b/common/src/main/resources/assets/stonezone/lang/zh_cn.json
@@ -5,9 +5,15 @@
 
   "block_type.twigs.column": "%s立柱",
 
+  "block_type.betterarcheology.cracked_bricks": "裂纹%s砖",
+  "block_type.betterarcheology.cracked_brick_stairs": "裂纹%s砖楼梯",
+  "block_type.betterarcheology.cracked_brick_slab": "裂纹%s砖台阶",
+
   "block_type.quark.vertical_slab": "%s竖直台阶",
   "block_type.quark.polished_vertical_slab": "磨制%s竖直台阶",
   "block_type.quark.pillar": "%s柱",
+  "block_type.quark.brick_lattice": "%s砖格栅",
+  "block_type.quark.carved_bricks": "雕纹%s砖",
 
   "block_type.bbb.layer": "%s层板",
   "block_type.bbb.smooth_layer": "平滑%s层板",
@@ -96,6 +102,29 @@
   "block_type.rechiseled.waves": "波纹%s",
   "block_type.rechiseled.waves_connecting": "波纹%s",
   "block_type.rechiseled.slated": "斜纹%s",
+
+  "block_type.blockus.herringbone_bricks": "人字形纹%s砖",
+  "block_type.blockus.smooth_stairs": "平滑%s楼梯",
+  "block_type.blockus.brick_pillar": "%s砖柱",
+  "block_type.blockus.circular_paving": "环纹%s",
+  "block_type.blockus.door": "%s门",
+  "block_type.blockus.tile_slab": "%s瓦台阶",
+  "block_type.blockus.tile_stairs": "%s瓦楼梯",
+  "block_type.blockus.tile_wall": "%s瓦墙",
+  "block_type.blockus.tiles": "%s瓦",
+  "block_type.blockus.trapdoor": "%s活板门",
+
+  "block_type.stonechest.chest": "%s箱子",
+  "item_type.stonechest.part": "%s部件",
+
+  "block_type.mcwbridges.brick_bridge":"%s砖桥",
+  "block_type.mcwbridges.mossy_brick_bridge":"覆苔%s砖桥",
+  "block_type.mcwbridges.bridge_pier":"%s桥梁支架",
+  "block_type.mcwbridges.mossy_bridge_pier":"覆苔%s桥梁支架",
+  "block_type.mcwbridges.brick_bridge_stair":"%s砖桥梯",
+  "block_type.mcwbridges.mossy_bridge_stair":"覆苔%s桥梯",
+  "block_type.mcwbridges.balustrade_bricks_bridge":"柱栏%s砖桥",
+  "block_type.mcwbridges.balustrade_mossy_bricks_bridge":"柱栏覆苔%s砖桥",
 
 
 
@@ -241,9 +270,9 @@
   "stone_type.deep_aether.aseterite": "紫菀石",
   "stone_type.deep_aether.clorite": "绿蔚石",
   "stone_type.deep_aether.raw_clorite": "粗绿蔚石",
-  "stone_type.deep_aether.aether_mud": "天泥",
   "stone_type.deep_aether.nimbus_stone": "疾雨石",
   "stone_type.deep_aether.light_nimbus_stone": "流光疾雨石",
+  "mud_type.deep_aether.aether_mud": "天泥",
 
   "stone_type.deeperdarker.sculk_stone": "幽匿石",
 
@@ -273,6 +302,8 @@
   "stone_type.quark.myalite": "幻境石",
   "stone_type.quark.permafrost": "永冻石",
   "stone_type.quark.soul_sandstone": "灵魂砂岩",
+  "stone_type.quark.midori": "绿",
+  "stone_type.quark.duskbound": "黯缚",
 
   "stone_type.railcraft.quarried_stone": "采掘岩",
   "stone_type.railcraft.abyssal_stone": "深渊岩",


### PR DESCRIPTION
This PR currently contains updates to `block_type`s and Quark's compat.

I would like to ask if the `stone_type` and `mud_type` part could be moved to Moonlight to provided wider support if other mods may utilize this system.
If applicable, this PR would instead delete the keys in question, and I would also open PRs that transfer `wood_type` and `leaves_type` in Wood Good to lib mod.